### PR TITLE
Add document parser module with LLM field extraction

### DIFF
--- a/doc_parser/__init__.py
+++ b/doc_parser/__init__.py
@@ -1,0 +1,3 @@
+from .parser import extract_key_lines
+
+__all__ = ["extract_key_lines"]

--- a/doc_parser/__main__.py
+++ b/doc_parser/__main__.py
@@ -1,0 +1,20 @@
+import argparse
+from . import extract_key_lines
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Extract key fields from a contract image"
+    )
+    parser.add_argument("--image", required=True, help="Path to document image")
+    parser.add_argument(
+        "--backend", default="openrouter", help="LLM backend (openrouter/local)"
+    )
+    args = parser.parse_args()
+
+    data = extract_key_lines(args.image, llm_backend=args.backend)
+    print(data)
+
+
+if __name__ == "__main__":
+    main()

--- a/doc_parser/parser.py
+++ b/doc_parser/parser.py
@@ -1,0 +1,22 @@
+from typing import Any, Dict
+
+from llm.router import LLMRouter
+from text_recognition import process_image
+
+
+def extract_key_lines(image_path: str, llm_backend: str = "openrouter") -> Dict[str, Any]:
+    """Extract key fields from a document image.
+
+    The function runs OCR via ``text_recognition`` without writing any files and
+    then asks the selected LLM backend to find contract fields, returning them
+    as JSON-compatible dictionary.
+    """
+    ocr_info = process_image(
+        image_path=image_path,
+        output_dir=None,
+        use_llm=False,
+        save_outputs=False,
+    )
+    blocks = ocr_info["blocks"]
+    router = LLMRouter(backend=llm_backend)
+    return router.extract_fields(blocks)


### PR DESCRIPTION
## Summary
- allow `text_recognition.process_image` to run without writing files by adding `save_outputs` flag
- add `doc_parser` module to extract contract key fields via LLM using OCR blocks

## Testing
- `python -m py_compile text_recognition/pipeline.py doc_parser/parser.py doc_parser/__main__.py`
- `python -m doc_parser --image examples/inputs/contract3.png --backend local` *(fails: No module named 'openai')*
- `pip install openai` *(fails: Could not find a version that satisfies the requirement openai)*

------
https://chatgpt.com/codex/tasks/task_e_68c69c206a608333a27e1dd640ac49f7