### PR TITLE
Add PDF page processing with logging

### DIFF
--- a/document_parser/__init__.py
+++ b/document_parser/__init__.py
@@ -1,22 +1,33 @@
-"""Document parsing module."""
+"""Document parsing module for PDF files."""
 
-from typing import Any, Dict
+from typing import Any, Dict, List
+import io
+import os
+import tempfile
 
+import fitz  # type: ignore
 from PIL import Image
 
 from text_recognition import process_image
 from text_recognition.utils import pil_to_data_url
 
 
-def parse_document(image_path: str, llm_backend: str = "openrouter", **ocr_kwargs: Any) -> Dict[str, Any]:
-    """Run OCR and extract structured fields using an LLM.
+def parse_document(
+    pdf_path: str,
+    llm_backend: str = "openrouter",
+    log_path: str = "process.log",
+    **ocr_kwargs: Any,
+) -> Dict[str, Any]:
+    """Run OCR on each PDF page and extract structured fields using an LLM.
 
     Parameters
     ----------
-    image_path:
-        Path to the input image to parse.
+    pdf_path:
+        Path to the input PDF to parse.
     llm_backend:
         Backend name for :class:`llm.router.LLMRouter`.
+    log_path:
+        Where to save the processing log.
     **ocr_kwargs:
         Additional keyword arguments forwarded to
         :func:`text_recognition.process_image`.
@@ -24,34 +35,53 @@ def parse_document(image_path: str, llm_backend: str = "openrouter", **ocr_kwarg
     Returns
     -------
     dict
-        A dictionary containing the OCR ``info`` from ``process_image`` and
-        the extracted ``fields`` from the LLM.
+        A dictionary containing ``pages`` with OCR info for each page and the
+        extracted ``fields`` from the LLM.
     """
-    info = process_image(image_path=image_path, llm_backend=llm_backend, **ocr_kwargs)
+    pages_info: List[Dict[str, Any]] = []
+    pages_for_llm: List[Dict[str, str]] = []
 
-    full_text = "\n".join(info.get("verified_lines", []))
-    image_b64 = pil_to_data_url(Image.open(image_path).convert("RGB"))
-    prompt = (
-        "Ты получаешь распознанный текст документа.\n"
-        "Задача: найти ключевые поля договора и вернуть JSON со структурой:\n"
-        "{\n"
-        '  "contract_number": "...",\n'
-        '  "date": "...",\n'
-        '  "parties": ["...", "..."],\n'
-        '  "amount": "...",\n'
-        '  "other": "..." (если есть)\n'
-        "}\n"
-        "Если поле не найдено — ставь пустую строку.\n"
-        "Дата должна быть полной (укажи число, месяц и год в жестком формате ДД.ММ.ГГГГ)."
-        "Возвращай полностью обзац + пункт(если есть) в каждом поле и передавать в оригинальном виде."
-        "Использовать переносы текста в ключевых полях можно только если переносы присутствуют на фото, иначе убрать."
-    )
+    with open(log_path, "w", encoding="utf-8") as log_file:
+        log_file.write(f"PDF: {pdf_path}\n")
+        doc = fitz.open(pdf_path)
+        for page_index, page in enumerate(doc, start=1):
+            log_file.write(f"Processing page {page_index}\n")
+            pix = page.get_pixmap()
+            image = Image.open(io.BytesIO(pix.tobytes("png"))).convert("RGB")
+            with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
+                image.save(tmp.name)
+                tmp_path = tmp.name
+            info = process_image(image_path=tmp_path, llm_backend=llm_backend, **ocr_kwargs)
+            os.unlink(tmp_path)
+            text = "\n".join(info.get("verified_lines", []))
+            image_b64 = pil_to_data_url(image)
+            pages_info.append({"page": page_index, "info": info})
+            pages_for_llm.append({"page": page_index, "text": text, "image_b64": image_b64})
+            log_file.write(f"Page {page_index}: {len(info.get('verified_lines', []))} lines\n")
 
-    from llm.router import LLMRouter
+        prompt = (
+            "Ты получаешь распознанный текст документа.\n"
+            "Задача: найти ключевые поля договора и вернуть JSON со структурой:\n"
+            "{\n"
+            '  "contract_number": "...",\n'
+            '  "date": "...",\n'
+            '  "parties": ["...", "..."],\n'
+            '  "amount": "...",\n'
+            '  "other": "..." (если есть)\n'
+            "}\n"
+            "Если поле не найдено — ставь пустую строку.\n"
+            "Дата должна быть полной (укажи число, месяц и год в жестком формате ДД.ММ.ГГГГ)."
+            "Возвращай полностью обзац + пункт(если есть) в каждом поле и передавать в оригинальном виде."
+            "Использовать переносы текста в ключевых полях можно только если переносы присутствуют на фото, иначе убрать."
+        )
 
-    llm = LLMRouter(backend=llm_backend)
-    fields = llm.extract_fields(full_text, image_b64, prompt)
-    return {"info": info, "fields": fields}
+        from llm.router import LLMRouter
+
+        llm = LLMRouter(backend=llm_backend)
+        fields = llm.extract_fields(pages_for_llm, prompt)
+        log_file.write("LLM extraction complete\n")
+
+    return {"pages": pages_info, "fields": fields}
 
 
 __all__ = ["parse_document"]

--- a/document_parser/__main__.py
+++ b/document_parser/__main__.py
@@ -13,11 +13,11 @@ from pathlib import Path
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Extract document fields from an image")
+    parser = argparse.ArgumentParser(description="Extract document fields from a PDF")
     parser.add_argument(
-        "--image",
-        default="test2.png",
-        help="Path to the input image",
+        "--pdf",
+        default="test.pdf",
+        help="Path to the input PDF file",
     )
     parser.add_argument(
         "--backend",
@@ -38,7 +38,7 @@ def main() -> None:
         from document_parser import parse_document  # type: ignore
 
     result = parse_document(
-        image_path=args.image,
+        pdf_path=args.pdf,
         llm_backend=args.backend,
         use_llm=args.use_ocr_llm,
     )

--- a/llm/local_llm.py
+++ b/llm/local_llm.py
@@ -11,5 +11,5 @@ class LocalLLM:
     def verify_text(self, image_b64: str, candidate_text: str):
         return {"corrected": candidate_text, "confidence": 0.5, "note": "Local LLM not implemented"}
 
-    def extract_fields(self, text: str, image_b64: str, prompt: str):
+    def extract_fields(self, pages, prompt: str):
         return {"note": "Local LLM not implemented"}

--- a/llm/openrouter_llm.py
+++ b/llm/openrouter_llm.py
@@ -51,12 +51,14 @@ class OpenRouterLLM:
         except Exception as e:
             return {"corrected": candidate_text, "confidence": 0.0, "error": str(e)}
 
-    def extract_fields(self, text: str, image_b64: str, prompt: str):
+    def extract_fields(self, pages, prompt: str):
         try:
-            content = [
-                {"type": "text", "text": f"{prompt}\n\n{text}"},
-                {"type": "image_url", "image_url": {"url": image_b64}},
-            ]
+            content = [{"type": "text", "text": prompt}]
+            for page in pages:
+                num = page.get("page", 0)
+                content.append({"type": "text", "text": f"Страница {num}"})
+                content.append({"type": "image_url", "image_url": {"url": page.get("image_b64", "")}})
+                content.append({"type": "text", "text": page.get("text", "")})
 
             resp = self.client.chat.completions.create(
                 model=self.model,

--- a/llm/router.py
+++ b/llm/router.py
@@ -1,5 +1,5 @@
 # llm/router.py
-from typing import Dict, Any
+from typing import Dict, Any, List
 from .openrouter_llm import OpenRouterLLM
 from .local_llm import LocalLLM
 
@@ -26,17 +26,6 @@ class LLMRouter:
         """
         return self.backend.verify_text(image_b64, candidate_text)
 
-    def extract_fields(self, text: str, image_b64: str, prompt: str) -> Dict[str, Any]:
-        """
-        Выделение ключевых полей из документа.
-
-        Parameters
-        ----------
-        text:
-            Полный извлечённый текст документа.
-        image_b64:
-            Изображение документа в base64.
-        prompt:
-            Подсказка для LLM.
-        """
-        return self.backend.extract_fields(text, image_b64, prompt)
+    def extract_fields(self, pages: List[Dict[str, str]], prompt: str) -> Dict[str, Any]:
+        """Выделение ключевых полей из документа."""
+        return self.backend.extract_fields(pages, prompt)


### PR DESCRIPTION
## Summary
- support parsing PDF files by converting each page into images and running OCR per page
- send page-specific images and recognized text to LLM and log each step to a text file
- update LLM router and OpenRouter backend to handle multiple pages with page numbers

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install pymupdf easyocr` *(failed: Could not find a version that satisfies the requirement pymupdf)*
- `pip install pillow` *(failed: Could not find a version that satisfies the requirement pillow)*
- `python -m document_parser --pdf dummy.pdf --backend local` *(failed: No module named 'fitz')*

------
https://chatgpt.com/codex/tasks/task_e_68c6ef12fa548333a51f27a386f221e2