### PR TITLE
Add Streamlit demo with progress and customizable prompt

### DIFF
--- a/document_parser/__init__.py
+++ b/document_parser/__init__.py
@@ -1,6 +1,6 @@
 """Document parsing module for PDF files."""
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Callable, Optional
 import io
 import os
 import tempfile
@@ -12,10 +12,33 @@ from text_recognition import process_image
 from text_recognition.utils import pil_to_data_url
 
 
+BASE_PROMPT = (
+    "Ты получаешь распознанный текст документа.\n"
+    "Задача: найти ключевые поля договора и вернуть JSON со структурой:\n"
+    "{\n"
+    '  "№ контракта": {"value": "...", "location": "..."},\n'
+    '  "дата заключения": {"value": "...", "location": "..."},\n'
+    '  "дата окончания": {"value": "...", "location": "..."},\n'
+    '  "контрагент": {"value": ["...", "..."], "location": "..."},\n'
+    '  "страна": {"value": "...", "location": "..."},\n'
+    '  "сумма контракта": {"value": "...", "location": "..."},\n'
+    '  "валюта контракта": {"value": "...", "location": "..."},\n'
+    '  "валюта платежа": {"value": "...", "location": "..."}\n'
+    "}\n"
+    "Каждое поле обязательно к заполнению.\n"
+    "Дата должна быть полной (укажи число, месяц и год в жестком формате ДД.ММ.ГГГГ).\n"
+    "Возвращай полностью обзац в каждом поле и передавать в оригинальном виде.\n"
+    "В каждом поле JSON обязательно должно быть указано расположение (страница + пункт(арабские цифры) или номер абзаца или номер строки).\n"
+    "Использовать переносы текста в ключевых полях можно только если переносы присутствуют на фото, иначе убрать.\n"
+)
+
+
 def parse_document(
     pdf_path: str,
     llm_backend: str = "openrouter",
     log_path: str = "process.log",
+    prompt: Optional[str] = None,
+    progress_cb: Optional[Callable[[float, str], None]] = None,
     **ocr_kwargs: Any,
 ) -> Dict[str, Any]:
     """Run OCR on each PDF page and extract structured fields using an LLM.
@@ -28,6 +51,12 @@ def parse_document(
         Backend name for :class:`llm.router.LLMRouter`.
     log_path:
         Where to save the processing log.
+    prompt:
+        Custom prompt for field extraction.  If ``None`` the built-in
+        :data:`BASE_PROMPT` is used.
+    progress_cb:
+        Optional callback receiving ``(progress, description)`` updates where
+        ``progress`` is a float from 0 to 1.
     **ocr_kwargs:
         Additional keyword arguments forwarded to
         :func:`text_recognition.process_image`.
@@ -44,6 +73,9 @@ def parse_document(
     with open(log_path, "w", encoding="utf-8") as log_file:
         log_file.write(f"PDF: {pdf_path}\n")
         doc = fitz.open(pdf_path)
+        total_pages = len(doc)
+        if progress_cb:
+            progress_cb(0.0, "Начало")
         for page_index, page in enumerate(doc, start=1):
             log_file.write(f"Processing page {page_index}\n")
             pix = page.get_pixmap()
@@ -58,34 +90,20 @@ def parse_document(
             pages_info.append({"page": page_index, "info": info})
             pages_for_llm.append({"page": page_index, "text": text, "image_b64": image_b64})
             log_file.write(f"Page {page_index}: {len(info.get('verified_lines', []))} lines\n")
-
-            prompt = (
-                "Ты получаешь распознанный текст документа.\n"
-                "Задача: найти ключевые поля договора и вернуть JSON со структурой:\n"
-                "{\n"
-                '  "№ контракта": {"value": "...", "location": "..."},\n'
-                '  "дата заключения": {"value": "...", "location": "..."},\n'
-                '  "дата окончания": {"value": "...", "location": "..."},\n'
-                '  "контрагент": {"value": ["...", "..."], "location": "..."},\n'
-                '  "страна": {"value": "...", "location": "..."},\n'
-                '  "сумма контракта": {"value": "...", "location": "..."},\n'
-                '  "валюта контракта": {"value": "...", "location": "..."},\n'
-                '  "валюта платежа": {"value": "...", "location": "..."}\n'
-                "}\n"
-                "Каждое поле обязательно к заполнению.\n"
-                "Дата должна быть полной (укажи число, месяц и год в жестком формате ДД.ММ.ГГГГ).\n"
-                "Возвращай полностью обзац в каждом поле и передавать в оригинальном виде.\n"
-                "В каждом поле JSON обязательно должно быть указано расположение (страница + пункт(арабские цифры) или номер абзаца или номер строки).\n"
-                "Использовать переносы текста в ключевых полях можно только если переносы присутствуют на фото, иначе убрать.\n"
-            )
+            if progress_cb:
+                progress_cb(page_index / (total_pages + 1), f"Обработка страницы {page_index}/{total_pages}")
 
         from llm.router import LLMRouter
 
         llm = LLMRouter(backend=llm_backend)
-        fields = llm.extract_fields(pages_for_llm, prompt)
+        if progress_cb:
+            progress_cb(total_pages / (total_pages + 1), "Извлечение полей LLM")
+        fields = llm.extract_fields(pages_for_llm, prompt or BASE_PROMPT)
         log_file.write("LLM extraction complete\n")
+        if progress_cb:
+            progress_cb(1.0, "Готово")
 
     return {"pages": pages_info, "fields": fields}
 
 
-__all__ = ["parse_document"]
+__all__ = ["parse_document", "BASE_PROMPT"]

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,58 @@
+import io
+import os
+import tempfile
+from typing import Dict, Any
+
+import pandas as pd
+import streamlit as st
+
+from document_parser import parse_document, BASE_PROMPT
+
+st.set_page_config(page_title="OCR Demo")
+st.title("OCR-MVP Demo")
+
+uploaded = st.file_uploader("Загрузите PDF", type=["pdf"])
+use_llm = st.checkbox("Включить OCR-LLM", value=False)
+prompt_text = st.text_area("Prompt", value=BASE_PROMPT, height=300)
+
+if uploaded and st.button("Запустить"):
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as tmp:
+        tmp.write(uploaded.getvalue())
+        pdf_path = tmp.name
+    progress_text = st.empty()
+    progress_bar = st.progress(0)
+
+    def cb(progress: float, desc: str) -> None:
+        progress_bar.progress(int(progress * 100))
+        progress_text.text(desc)
+
+    result: Dict[str, Any] = parse_document(
+        pdf_path=pdf_path,
+        use_llm=use_llm,
+        prompt=prompt_text,
+        progress_cb=cb,
+    )
+    os.unlink(pdf_path)
+
+    st.subheader("Распознанные поля")
+    st.json(result["fields"])
+
+    df = pd.DataFrame([
+        {"field": k, "value": v.get("value"), "location": v.get("location")}
+        for k, v in result["fields"].items()
+    ])
+    buf = io.BytesIO()
+    df.to_excel(buf, index=False)
+    st.download_button(
+        "Скачать как Excel",
+        data=buf.getvalue(),
+        file_name="fields.xlsx",
+        mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    )
+
+    st.subheader("OCR страницы")
+    for page in result["pages"]:
+        st.image(page["info"]["overlay"], caption=f"Страница {page['page']}")
+        with st.expander(f"Блоки страницы {page['page']}"):
+            for block in page["info"]["blocks"]:
+                st.image(block["crop_data"], caption=block["final"]["text"])


### PR DESCRIPTION
## Summary
- Expose `BASE_PROMPT` and add progress callback support to `parse_document`
- Create Streamlit demo app with file upload, OCR-LLM toggle, progress bar, editable prompt, and Excel export

## Testing
- `python -m py_compile document_parser/__init__.py streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6fcd2f0508333afb846764dedfa7d